### PR TITLE
Add exported functions missing from headers.

### DIFF
--- a/include/safe_mem_lib.h
+++ b/include/safe_mem_lib.h
@@ -57,6 +57,10 @@ extern errno_t memcmp16_s(const uint16_t *dest, rsize_t dmax,
 extern errno_t memcmp32_s(const uint32_t *dest, rsize_t dmax,
                           const uint32_t *src, rsize_t slen, int *diff);
 
+/* wide compare memory */
+extern errno_t wmemcmp_s(const wchar_t *dest, rsize_t dmax,
+                         const wchar_t *src,  rsize_t smax, int *diff);
+
 
 /* copy memory */
 extern errno_t memcpy_s(void *dest, rsize_t dmax,
@@ -100,6 +104,9 @@ extern errno_t memset16_s(uint16_t *dest, rsize_t dmax, uint16_t value);
 
 /* set uint32_t */
 extern errno_t memset32_s(uint32_t *dest, rsize_t dmax, uint32_t value);
+
+/* wide set bytes */
+extern errno_t wmemset_s(wchar_t *dest, wchar_t value, rsize_t len);
 
 
 /* byte zero */

--- a/include/safe_str_lib.h
+++ b/include/safe_str_lib.h
@@ -95,6 +95,10 @@ strcpy_s(char *dest, rsize_t dmax, const char *src);
 extern char *
 stpcpy_s(char *dest, rsize_t dmax, const char *src, errno_t *err);
 
+/* string copy */
+extern char *
+stpncpy_s(char *dest, rsize_t dmax, const char *src, rsize_t smax, errno_t *err);
+
 /* fixed char array copy */
 extern errno_t
 strcpyfld_s(char *dest, rsize_t dmax, const char *src, rsize_t slen);
@@ -258,6 +262,31 @@ strtouppercase_s(char *str, rsize_t slen);
 /* zero an entire string with nulls */
 extern errno_t
 strzero_s(char *dest, rsize_t dmax);
+
+
+/* wide string copy */
+extern wchar_t *
+wcpcpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, errno_t *err);
+
+/* wide string concatenate */
+extern errno_t
+wcscat_s(wchar_t* dest, rsize_t dmax, const wchar_t* src);
+
+/* fitted wide string concatenate */
+extern errno_t
+wcsncat_s(wchar_t *dest, rsize_t dmax, const wchar_t *src, rsize_t slen);
+
+/* wide string copy */
+errno_t
+wcscpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src);
+
+/* fitted wide string copy */
+extern errno_t
+wcsncpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, rsize_t slen);
+
+/* wide string length */
+extern rsize_t
+wcsnlen_s(const wchar_t *dest, rsize_t dmax);
 
 
 #endif   /* __SAFE_STR_LIB_H__ */


### PR DESCRIPTION
The functions added in this commit are EXPORTed, but not included in the current header files.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>