### PR TITLE
Fixed EXPORT statements

### DIFF
--- a/safeclib/abort_handler_s.c
+++ b/safeclib/abort_handler_s.c
@@ -71,4 +71,4 @@ void abort_handler_s(const char *msg, void *ptr, errno_t error)
 		 (msg) ? msg : "Null message");
 	slabort();
 }
-EXPORT_SYMBOL(abort_handler_s);
+EXPORT_SYMBOL(abort_handler_s)

--- a/safeclib/ignore_handler_s.c
+++ b/safeclib/ignore_handler_s.c
@@ -69,4 +69,4 @@ void ignore_handler_s(const char *msg, void *ptr, errno_t error)
 		       (msg) ? msg : "Null message");
 	return;
 }
-EXPORT_SYMBOL(ignore_handler_s);
+EXPORT_SYMBOL(ignore_handler_s)

--- a/safeclib/memcmp16_s.c
+++ b/safeclib/memcmp16_s.c
@@ -170,4 +170,4 @@ memcmp16_s (const uint16_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp16_s);
+EXPORT_SYMBOL(memcmp16_s)

--- a/safeclib/memcmp32_s.c
+++ b/safeclib/memcmp32_s.c
@@ -164,4 +164,4 @@ memcmp32_s (const uint32_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp32_s);
+EXPORT_SYMBOL(memcmp32_s)

--- a/safeclib/memcmp_s.c
+++ b/safeclib/memcmp_s.c
@@ -171,4 +171,4 @@ memcmp_s (const void *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcmp_s);
+EXPORT_SYMBOL(memcmp_s)

--- a/safeclib/memcpy16_s.c
+++ b/safeclib/memcpy16_s.c
@@ -148,4 +148,4 @@ memcpy16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcpy16_s);
+EXPORT_SYMBOL(memcpy16_s)

--- a/safeclib/memcpy32_s.c
+++ b/safeclib/memcpy32_s.c
@@ -147,4 +147,4 @@ memcpy32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memcpy32_s);
+EXPORT_SYMBOL(memcpy32_s)

--- a/safeclib/memcpy_s.c
+++ b/safeclib/memcpy_s.c
@@ -160,4 +160,4 @@ memcpy_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(memcpy_s);
+EXPORT_SYMBOL(memcpy_s)

--- a/safeclib/memmove16_s.c
+++ b/safeclib/memmove16_s.c
@@ -148,4 +148,4 @@ memmove16_s (uint16_t *dest, rsize_t dmax, const uint16_t *src, rsize_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove16_s);
+EXPORT_SYMBOL(memmove16_s)

--- a/safeclib/memmove32_s.c
+++ b/safeclib/memmove32_s.c
@@ -147,4 +147,4 @@ memmove32_s (uint32_t *dest, rsize_t dmax, const uint32_t *src, rsize_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove32_s);
+EXPORT_SYMBOL(memmove32_s)

--- a/safeclib/memmove_s.c
+++ b/safeclib/memmove_s.c
@@ -146,4 +146,4 @@ memmove_s (void *dest, rsize_t dmax, const void *src, rsize_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memmove_s);
+EXPORT_SYMBOL(memmove_s)

--- a/safeclib/memset16_s.c
+++ b/safeclib/memset16_s.c
@@ -102,4 +102,4 @@ memset16_s (uint16_t *dest, rsize_t len, uint16_t value)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memset16_s);
+EXPORT_SYMBOL(memset16_s)

--- a/safeclib/memset32_s.c
+++ b/safeclib/memset32_s.c
@@ -102,4 +102,4 @@ memset32_s (uint32_t *dest, rsize_t len, uint32_t value)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memset32_s);
+EXPORT_SYMBOL(memset32_s)

--- a/safeclib/memset_s.c
+++ b/safeclib/memset_s.c
@@ -102,4 +102,4 @@ memset_s (void *dest, rsize_t len, uint8_t value)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memset_s);
+EXPORT_SYMBOL(memset_s)

--- a/safeclib/memzero16_s.c
+++ b/safeclib/memzero16_s.c
@@ -104,4 +104,4 @@ memzero16_s (uint16_t *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero16_s);
+EXPORT_SYMBOL(memzero16_s)

--- a/safeclib/memzero32_s.c
+++ b/safeclib/memzero32_s.c
@@ -105,4 +105,4 @@ memzero32_s (uint32_t *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero32_s);
+EXPORT_SYMBOL(memzero32_s)

--- a/safeclib/memzero_s.c
+++ b/safeclib/memzero_s.c
@@ -104,4 +104,4 @@ memzero_s (void *dest, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(memzero_s);
+EXPORT_SYMBOL(memzero_s)

--- a/safeclib/safe_mem_constraint.c
+++ b/safeclib/safe_mem_constraint.c
@@ -98,7 +98,7 @@ set_mem_constraint_handler_s (constraint_handler_t handler)
     }
     return prev_handler;
 }
-EXPORT_SYMBOL(set_mem_constraint_handler_s);
+EXPORT_SYMBOL(set_mem_constraint_handler_s)
 
 
 /**

--- a/safeclib/safe_str_constraint.c
+++ b/safeclib/safe_str_constraint.c
@@ -102,7 +102,7 @@ set_str_constraint_handler_s (constraint_handler_t handler)
     }
     return prev_handler;
 }
-EXPORT_SYMBOL(set_str_constraint_handler_s);
+EXPORT_SYMBOL(set_str_constraint_handler_s)
 
 
 /**

--- a/safeclib/stpcpy_s.c
+++ b/safeclib/stpcpy_s.c
@@ -231,4 +231,4 @@ stpcpy_s(char *dest, rsize_t dmax, const char *src, errno_t *err)
     *err = RCNEGATE(ESNOSPC);
     return NULL;
 }
-EXPORT_SYMBOL(stpcpy_s);
+EXPORT_SYMBOL(stpcpy_s)

--- a/safeclib/strcasecmp_s.c
+++ b/safeclib/strcasecmp_s.c
@@ -141,4 +141,4 @@ strcasecmp_s (const char *dest, rsize_t dmax,
     *indicator = (toupper(*udest) - toupper(*usrc));
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcasecmp_s);
+EXPORT_SYMBOL(strcasecmp_s)

--- a/safeclib/strcasestr_s.c
+++ b/safeclib/strcasestr_s.c
@@ -177,3 +177,4 @@ strcasestr_s (char *dest, rsize_t dmax,
     *substring = NULL;
     return (ESNOTFND);
 }
+EXPORT_SYMBOL(strcasestr_s)

--- a/safeclib/strcat_s.c
+++ b/safeclib/strcat_s.c
@@ -229,4 +229,4 @@ strcat_s (char *dest, rsize_t dmax, const char *src)
 
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strcat_s);
+EXPORT_SYMBOL(strcat_s)

--- a/safeclib/strcmp_s.c
+++ b/safeclib/strcmp_s.c
@@ -137,4 +137,4 @@ strcmp_s (const char *dest, rsize_t dmax,
     *indicator = *dest - *src;
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcmp_s);
+EXPORT_SYMBOL(strcmp_s)

--- a/safeclib/strcmpfld_s.c
+++ b/safeclib/strcmpfld_s.c
@@ -140,3 +140,4 @@ strcmpfld_s (const char *dest, rsize_t dmax,
     *indicator = *dest - *src;
     return (EOK);
 }
+EXPORT_SYMBOL(strcmpfld_s)

--- a/safeclib/strcpy_s.c
+++ b/safeclib/strcpy_s.c
@@ -195,4 +195,4 @@ strcpy_s (char *dest, rsize_t dmax, const char *src)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strcpy_s);
+EXPORT_SYMBOL(strcpy_s)

--- a/safeclib/strcpyfld_s.c
+++ b/safeclib/strcpyfld_s.c
@@ -197,3 +197,4 @@ strcpyfld_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
     while (dmax) { *dest = '\0'; dmax--; dest++; }
     return (EOK);
 }
+EXPORT_SYMBOL(strcpyfld_s)

--- a/safeclib/strcpyfldin_s.c
+++ b/safeclib/strcpyfldin_s.c
@@ -200,3 +200,4 @@ strcpyfldin_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strcpyfldin_s)

--- a/safeclib/strcpyfldout_s.c
+++ b/safeclib/strcpyfldout_s.c
@@ -202,3 +202,4 @@ strcpyfldout_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strcpyfldout_s)

--- a/safeclib/strcspn_s.c
+++ b/safeclib/strcspn_s.c
@@ -162,4 +162,4 @@ strcspn_s (const char *dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strcspn_s);
+EXPORT_SYMBOL(strcspn_s)

--- a/safeclib/strfirstchar_s.c
+++ b/safeclib/strfirstchar_s.c
@@ -125,3 +125,4 @@ strfirstchar_s (char *dest, rsize_t dmax, char c, char **first)
 
     return (ESNOTFND);
 }
+EXPORT_SYMBOL(strfirstchar_s)

--- a/safeclib/strfirstdiff_s.c
+++ b/safeclib/strfirstdiff_s.c
@@ -140,3 +140,4 @@
 
     return (ESNODIFF);
 }
+EXPORT_SYMBOL(strfirstdiff_s)

--- a/safeclib/strfirstsame_s.c
+++ b/safeclib/strfirstsame_s.c
@@ -143,3 +143,4 @@ strfirstsame_s (const char *dest, rsize_t dmax,
 
     return (ESNOTFND);
 }
+EXPORT_SYMBOL(strfirstsame_s)

--- a/safeclib/strisalphanumeric_s.c
+++ b/safeclib/strisalphanumeric_s.c
@@ -117,3 +117,4 @@ strisalphanumeric_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strisalphanumeric_s)

--- a/safeclib/strisascii_s.c
+++ b/safeclib/strisascii_s.c
@@ -108,3 +108,4 @@ strisascii_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strisascii_s)

--- a/safeclib/strisdigit_s.c
+++ b/safeclib/strisdigit_s.c
@@ -110,3 +110,4 @@ strisdigit_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strisdigit_s)

--- a/safeclib/strishex_s.c
+++ b/safeclib/strishex_s.c
@@ -116,3 +116,4 @@ strishex_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strishex_s)

--- a/safeclib/strislowercase_s.c
+++ b/safeclib/strislowercase_s.c
@@ -116,3 +116,4 @@ strislowercase_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strislowercase_s)

--- a/safeclib/strismixedcase_s.c
+++ b/safeclib/strismixedcase_s.c
@@ -117,3 +117,4 @@ strismixedcase_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strismixedcase_s)

--- a/safeclib/strispassword_s.c
+++ b/safeclib/strispassword_s.c
@@ -166,3 +166,4 @@ strispassword_s (const char *dest, rsize_t dmax)
         return (false);
     }
 }
+EXPORT_SYMBOL(strispassword_s)

--- a/safeclib/strisuppercase_s.c
+++ b/safeclib/strisuppercase_s.c
@@ -115,3 +115,4 @@ strisuppercase_s (const char *dest, rsize_t dmax)
 
     return (true);
 }
+EXPORT_SYMBOL(strisuppercase_s)

--- a/safeclib/strlastchar_s.c
+++ b/safeclib/strlastchar_s.c
@@ -129,3 +129,4 @@ strlastchar_s(char *dest, rsize_t dmax, char c, char **last)
         return (EOK);
     }
 }
+EXPORT_SYMBOL(strlastchar_s)

--- a/safeclib/strlastdiff_s.c
+++ b/safeclib/strlastdiff_s.c
@@ -149,3 +149,4 @@ strlastdiff_s(const char *dest, rsize_t dmax,
         return (ESNODIFF);
     }
 }
+EXPORT_SYMBOL(strlastdiff_s)

--- a/safeclib/strlastsame_s.c
+++ b/safeclib/strlastsame_s.c
@@ -150,3 +150,4 @@ strlastsame_s (const char *dest, rsize_t dmax,
         return (ESNOTFND);
     }
 }
+EXPORT_SYMBOL(strlastsame_s)

--- a/safeclib/strljustify_s.c
+++ b/safeclib/strljustify_s.c
@@ -157,3 +157,4 @@ strljustify_s (char *dest, rsize_t dmax)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strljustify_s)

--- a/safeclib/strncat_s.c
+++ b/safeclib/strncat_s.c
@@ -262,4 +262,4 @@ strncat_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strncat_s);
+EXPORT_SYMBOL(strncat_s)

--- a/safeclib/strncpy_s.c
+++ b/safeclib/strncpy_s.c
@@ -235,4 +235,4 @@ strncpy_s (char *dest, rsize_t dmax, const char *src, rsize_t slen)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(strncpy_s);
+EXPORT_SYMBOL(strncpy_s)

--- a/safeclib/strnlen_s.c
+++ b/safeclib/strnlen_s.c
@@ -109,4 +109,4 @@ strnlen_s (const char *dest, rsize_t dmax)
 
     return RCNEGATE(count);
 }
-EXPORT_SYMBOL(strnlen_s);
+EXPORT_SYMBOL(strnlen_s)

--- a/safeclib/strnterminate_s.c
+++ b/safeclib/strnterminate_s.c
@@ -110,3 +110,4 @@ strnterminate_s (char *dest, rsize_t dmax)
 
     return (count);
 }
+EXPORT_SYMBOL(strnterminate_s)

--- a/safeclib/strpbrk_s.c
+++ b/safeclib/strpbrk_s.c
@@ -160,4 +160,4 @@ strpbrk_s (char *dest, rsize_t dmax,
 
     return RCNEGATE(ESNOTFND);
 }
-EXPORT_SYMBOL(strpbrk_s);
+EXPORT_SYMBOL(strpbrk_s)

--- a/safeclib/strprefix_s.c
+++ b/safeclib/strprefix_s.c
@@ -125,3 +125,4 @@ strprefix_s (const char *dest, rsize_t dmax, const char *src)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strprefix_s)

--- a/safeclib/strremovews_s.c
+++ b/safeclib/strremovews_s.c
@@ -161,3 +161,4 @@ strremovews_s (char *dest, rsize_t dmax)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strremovews_s)

--- a/safeclib/strspn_s.c
+++ b/safeclib/strspn_s.c
@@ -167,4 +167,4 @@ strspn_s (const char *dest, rsize_t dmax,
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(strspn_s);
+EXPORT_SYMBOL(strspn_s)

--- a/safeclib/strstr_s.c
+++ b/safeclib/strstr_s.c
@@ -176,4 +176,4 @@ strstr_s (char *dest, rsize_t dmax,
     *substring = NULL;
     return RCNEGATE(ESNOTFND);
 }
-EXPORT_SYMBOL(strstr_s);
+EXPORT_SYMBOL(strstr_s)

--- a/safeclib/strtok_s.c
+++ b/safeclib/strtok_s.c
@@ -321,3 +321,5 @@ strtok_s(char *dest, rsize_t *dmax, const char *src, char **ptr)
     *dmax = dlen;
     return (ptoken);
 }
+EXPORT_SYMBOL(strtok_s)
+

--- a/safeclib/strtolowercase_s.c
+++ b/safeclib/strtolowercase_s.c
@@ -112,3 +112,4 @@ strtolowercase_s (char *dest, rsize_t dmax)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strtolowercase_s)

--- a/safeclib/strtouppercase_s.c
+++ b/safeclib/strtouppercase_s.c
@@ -112,3 +112,4 @@ strtouppercase_s (char *dest, rsize_t dmax)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strtouppercase_s)

--- a/safeclib/strzero_s.c
+++ b/safeclib/strzero_s.c
@@ -100,3 +100,4 @@ strzero_s (char *dest, rsize_t dmax)
 
     return (EOK);
 }
+EXPORT_SYMBOL(strzero_s)

--- a/safeclib/wcpcpy_s.c
+++ b/safeclib/wcpcpy_s.c
@@ -216,4 +216,4 @@ wcpcpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, errno_t *err)
     *err = RCNEGATE(ESNOSPC);
     return NULL;
 }
-EXPORT_SYMBOL(wcpcpy_s);
+EXPORT_SYMBOL(wcpcpy_s)

--- a/safeclib/wcscat_s.c
+++ b/safeclib/wcscat_s.c
@@ -223,4 +223,4 @@ wcscat_s(wchar_t* dest, rsize_t dmax, const wchar_t* src)
 
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcscat_s);
+EXPORT_SYMBOL(wcscat_s)

--- a/safeclib/wcscpy_s.c
+++ b/safeclib/wcscpy_s.c
@@ -204,4 +204,4 @@ wcscpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcscpy_s);
+EXPORT_SYMBOL(wcscpy_s)

--- a/safeclib/wcsncat_s.c
+++ b/safeclib/wcsncat_s.c
@@ -266,4 +266,4 @@ wcsncat_s (wchar_t *dest, rsize_t dmax, const wchar_t *src, rsize_t slen)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcsncat_s);
+EXPORT_SYMBOL(wcsncat_s)

--- a/safeclib/wcsncpy_s.c
+++ b/safeclib/wcsncpy_s.c
@@ -238,4 +238,4 @@ wcsncpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, rsize_t slen)
                  ESNOSPC);
     return RCNEGATE(ESNOSPC);
 }
-EXPORT_SYMBOL(wcsncpy_s);
+EXPORT_SYMBOL(wcsncpy_s)

--- a/safeclib/wcsnlen_s.c
+++ b/safeclib/wcsnlen_s.c
@@ -110,4 +110,4 @@ wcsnlen_s (const wchar_t *dest, rsize_t dmax)
 
     return RCNEGATE(count);
 }
-EXPORT_SYMBOL(wcsnlen_s);
+EXPORT_SYMBOL(wcsnlen_s)

--- a/safeclib/wmemcmp_s.c
+++ b/safeclib/wmemcmp_s.c
@@ -166,4 +166,4 @@ wmemcmp_s (const wchar_t *dest, rsize_t dmax,
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemcmp_s);
+EXPORT_SYMBOL(wmemcmp_s)

--- a/safeclib/wmemcpy_s.c
+++ b/safeclib/wmemcpy_s.c
@@ -155,4 +155,4 @@ wmemcpy_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, rsize_t smax)
 
     return RCNEGATE(EOK);
 }
-EXPORT_SYMBOL(wmemcpy_s);
+EXPORT_SYMBOL(wmemcpy_s)

--- a/safeclib/wmemmove_s.c
+++ b/safeclib/wmemmove_s.c
@@ -147,4 +147,4 @@ wmemmove_s(wchar_t* dest, rsize_t dmax, const wchar_t* src, size_t smax)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemmove_s);
+EXPORT_SYMBOL(wmemmove_s)

--- a/safeclib/wmemset_s.c
+++ b/safeclib/wmemset_s.c
@@ -102,4 +102,4 @@ wmemset_s (wchar_t *dest, wchar_t value, rsize_t len)
 
     return (RCNEGATE(EOK));
 }
-EXPORT_SYMBOL(wmemset_s);
+EXPORT_SYMBOL(wmemset_s)


### PR DESCRIPTION
Some EXPORT statements had a semicolon, which caused compiler errors with the ARM compiler; others were missing an appropriate EXPORT statement altogether.