### PR TITLE
libsafec: make headers include-able from c++ code

### DIFF
--- a/include/safe_lib.h
+++ b/include/safe_lib.h
@@ -33,6 +33,10 @@
 #ifndef __SAFE_LIB_H__
 #define __SAFE_LIB_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "safe_types.h"
 #include "safe_lib_errno.h"
 
@@ -58,4 +62,7 @@ extern void ignore_handler_s(const char *msg, void *ptr, errno_t error);
 #include "safe_mem_lib.h"
 #include "safe_str_lib.h"
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* __SAFE_LIB_H__ */


### PR DESCRIPTION
Add extern "C" envelope around main include file to
enable include from c++ code.

Signed-off-by: Alexander Usyskin <alexander.usyskin@intel.com>
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>