### PR TITLE
libsafec: wmemset_s.c scilence compilation warning

### DIFF
--- a/safeclib/wmemset_s.c
+++ b/safeclib/wmemset_s.c
@@ -98,7 +98,7 @@ wmemset_s (wchar_t *dest, wchar_t value, rsize_t len)
         return (RCNEGATE(ESLEMAX));
     }
 
-    mem_prim_set32(dest, len, value);
+    mem_prim_set32((uint32_t *)dest, len, value);
 
     return (RCNEGATE(EOK));
 }


### PR DESCRIPTION
We can safely cast wchar_t * to uint32_t in this case, in order to silence the
following warning:

safeclib/wmemset_s.c: In function ‘wmemset_s’:
safeclib/wmemset_s.c:101:20: warning: pointer targets in passing argument 1 of ‘mem_prim_set32’ differ in signedness [-Wpointer-sign]
     mem_prim_set32(dest, len, value);
                    ^~~~
In file included from safeclib/wmemset_s.c:34:
safeclib/mem_primitives_lib.h:71:1: note: expected ‘uint32_t *’ {aka ‘unsigned int *’} but argument is of type ‘wchar_t *’ {aka ‘int *’}

mem_prim_set32(uint32_t *dest, uint32_t dmax, uint32_t value);

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>