### PR TITLE
safestringlib: conditional inclusion of errno.h

### DIFF
--- a/include/safe_lib_errno.h
+++ b/include/safe_lib_errno.h
@@ -36,7 +36,9 @@
 #ifdef __KERNEL__
 # include <linux/errno.h>
 #else
+#ifndef __LOCAL_ERRNO__
 #include <errno.h>
+#endif
 #endif /* __KERNEL__ */
 
 /*

--- a/include/safe_types.h
+++ b/include/safe_types.h
@@ -58,7 +58,9 @@ typedef int errno_t;
 
 #include <inttypes.h>
 #include <stdint.h>
+#ifndef __LOCAL_ERRNO__
 #include <errno.h>
+#endif
 
 typedef int errno_t;
 


### PR DESCRIPTION
o While compiling for non-Linux based platforms where errno.h
  is not available, a new compile time flag is included.

o Defining __LOCAL_ERRNO__ allows the safestring to compile
  without looking for errno.h

Signed-off-by: Divneil Rai Wadhawan <divneil.r.wadhawan@intel.com>