### PR TITLE
Unit test fixes

### DIFF
--- a/unittests/test_strisalphanumeric_s.c
+++ b/unittests/test_strisalphanumeric_s.c
@@ -16,7 +16,7 @@ int test_strisalphanumeric_s()
 {
     bool rc;
 
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -40,7 +40,7 @@ int test_strisalphanumeric_s()
 /*--------------------------------------------------*/
 
     /* exceeds max */
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strisalphanumeric_s("test", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strisascii_s.c
+++ b/unittests/test_strisascii_s.c
@@ -15,7 +15,7 @@ int test_strisascii_s()
 {
     bool rc;
 
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -38,7 +38,7 @@ int test_strisascii_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strisascii_s("test", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strisdigit_s.c
+++ b/unittests/test_strisdigit_s.c
@@ -14,7 +14,7 @@ int test_strisdigit_s()
 {
     bool rc;
 
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -37,7 +37,7 @@ int test_strisdigit_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strisdigit_s("1234", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strishex_s.c
+++ b/unittests/test_strishex_s.c
@@ -14,7 +14,7 @@
 int test_strishex_s()
 {
     bool rc;
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -46,7 +46,7 @@ int test_strishex_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strishex_s("1234", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strislowercase_s.c
+++ b/unittests/test_strislowercase_s.c
@@ -14,7 +14,7 @@
 int test_strislowercase_s()
 {
     bool rc;
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -28,7 +28,7 @@ int test_strislowercase_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strislowercase_s("test", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strispassword_s.c
+++ b/unittests/test_strispassword_s.c
@@ -14,7 +14,7 @@
 int test_strispassword_s()
 {
     bool rc;
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/

--- a/unittests/test_strisuppercase_s.c
+++ b/unittests/test_strisuppercase_s.c
@@ -14,7 +14,7 @@
 int test_strisuppercase_s()
 {
     bool rc;
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -28,7 +28,7 @@ int test_strisuppercase_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strisuppercase_s("test", len);
     if (rc != false) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strljustify_s.c
+++ b/unittests/test_strljustify_s.c
@@ -15,7 +15,7 @@ int test_strljustify_s()
 {
     errno_t rc;
     int ind;
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -38,7 +38,7 @@ int test_strljustify_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strljustify_s("test", len);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strremovews_s.c
+++ b/unittests/test_strremovews_s.c
@@ -16,7 +16,7 @@ int test_strremovews_s()
     errno_t rc;
     int ind;
 
-    uint32_t len;
+    rsize_t len;
     char   str[LEN];
 
 /*--------------------------------------------------*/
@@ -39,7 +39,7 @@ int test_strremovews_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strremovews_s("test", len);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strtolowercase_s.c
+++ b/unittests/test_strtolowercase_s.c
@@ -37,7 +37,7 @@ int test_strtolowercase_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
     rc = strtolowercase_s("test", len);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",

--- a/unittests/test_strtouppercase_s.c
+++ b/unittests/test_strtouppercase_s.c
@@ -50,9 +50,7 @@ int test_strtouppercase_s()
 
 /*--------------------------------------------------*/
 
-/* FIXME: known bug: this test causes a bus error if the string max size is
-   not restricted via RSIZE_MAX_STR */
-    len = 99999;
+    len = RSIZE_MAX_STR+1;
 	//printf("debug - 04\n");
     rc = strtouppercase_s("test", len);
     if (rc != ESLEMAX) {

--- a/unittests/test_wcpcpy_s.c
+++ b/unittests/test_wcpcpy_s.c
@@ -129,7 +129,7 @@ printf("Test #%d:\n", ++testno);
 /* 3  Test for too large destination size              */
     printf("Test #%d:\n", ++testno);
 
-    ret = wcpcpy_s(str1, (RSIZE_MAX_STR+1), str2, &rc);
+    ret = wcpcpy_s(str1, (RSIZE_MAX_STR/sizeof(wchar_t))+1, str2, &rc);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc );

--- a/unittests/test_wcscat_s.c
+++ b/unittests/test_wcscat_s.c
@@ -86,7 +86,7 @@ int test_wcscat_s (void)
 /* 4  Test  Exceed Maximum size of destination     */
     printf("Test #%d:\n", ++testno);
 
-    rc = wcscat_s(str1, (RSIZE_MAX_STR+1), str2);
+    rc = wcscat_s(str1, (RSIZE_MAX_STR/sizeof(wchar_t))+1, str2);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc);

--- a/unittests/test_wcscpy_s.c
+++ b/unittests/test_wcscpy_s.c
@@ -72,8 +72,8 @@
 #include "test_private.h"
 #include "safe_str_lib.h"
 
+#define LEN   128
 #define MAX   ( 128*4 )
-#define LEN   ( 128*4 )
 
 static wchar_t   str1[LEN];
 static wchar_t   str2[LEN];
@@ -118,7 +118,7 @@ printf("Test #%d:\n", ++testno);
 /* 3  Test for too large destination size              */
 	printf("Test #%d:\n", ++testno);
 
-	rc = wcscpy_s(str1, (RSIZE_MAX_STR+1), str2);
+	rc = wcscpy_s(str1, (RSIZE_MAX_STR/sizeof(wchar_t))+1, str2);
 	if (rc != ESLEMAX) {
 		printf("%s %u   Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc );

--- a/unittests/test_wcscpy_s.c
+++ b/unittests/test_wcscpy_s.c
@@ -279,7 +279,7 @@ printf("Test #%d:\n", ++testno);
                      __FUNCTION__, __LINE__,  rc );
     }
 
-    rc = memcmp_s(str2, LEN, str1, (sz+1)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str2, MAX, str1, (sz+1)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u   Error -%ls- <> -%ls-\n",
                      __FUNCTION__, __LINE__,  str2, str1);
@@ -300,7 +300,7 @@ printf("Test #%d:\n", ++testno);
                      __FUNCTION__, __LINE__,  rc );
     }
 
-    rc = memcmp_s(str1, LEN, str2, (sz)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (sz)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls- <> -%ls-  (smax=%lu) Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, str2, sz, rc );
@@ -325,7 +325,7 @@ printf("Test #%d:\n", ++testno);
             printf("%s %u (sz=%lu <> 5) Error rc=%u \n",
                          __FUNCTION__, __LINE__,  sz, rc );
     }
-    rc = memcmp_s(str1, LEN, str2, (sz)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (sz)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls- <> -%ls-  (size=%lu) Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, str2, sz, rc );
@@ -383,7 +383,7 @@ printf("Test #%d:\n", ++testno);
                      __FUNCTION__, __LINE__,  rc );
     }
 
-    rc = memcmp_s(str1, LEN, str2, (3)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (3)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls-  Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, rc );
@@ -404,7 +404,7 @@ printf("Test #%d:\n", ++testno);
                      __FUNCTION__, __LINE__,  rc );
     }
 
-    rc = memcmp_s(str1, LEN, str2, (3)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (3)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls-  Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, rc );

--- a/unittests/test_wcscpy_s.c
+++ b/unittests/test_wcscpy_s.c
@@ -155,7 +155,7 @@ printf("Test #%d:\n", ++testno);
 /* 5  Test for Src is same as dest, but source too long */
     printf("Test #%d:\n", ++testno);
 
-    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
     rc = wcscpy_s(str1, 5, str1);
     if (rc != ESLEMAX) {
@@ -167,7 +167,7 @@ printf("Test #%d:\n", ++testno);
 /* 6  Test copy the same string onto itself            */
     printf("Test #%d:\n", ++testno);
 
-    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
 	rc = wcscpy_s(str1, LEN, str1);
 	if (rc != EOK) {

--- a/unittests/test_wcsncat_s.c
+++ b/unittests/test_wcsncat_s.c
@@ -119,7 +119,7 @@ int test_wcsncat_s (void)
 /* 3  Test  Exceed Maximum possible size of source     */
 	printf("Test #%d:\n", ++testno);
 
-	rc = wcsncat_s(str1, LEN, str2, (RSIZE_MAX_STR+1));
+	rc = wcsncat_s(str1, LEN, str2, (RSIZE_MAX_STR/sizeof(wchar_t))+1);
 	if (rc != ESLEMAX) {
 		printf("%s %u   Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);
@@ -138,7 +138,7 @@ int test_wcsncat_s (void)
 /* 5  Test  Exceed Maximum size of destination     */
     printf("Test #%d:\n", ++testno);
 
-    rc = wcsncat_s(str1, (RSIZE_MAX_STR+1), str2, LEN);
+    rc = wcsncat_s(str1, (RSIZE_MAX_STR/sizeof(wchar_t))+1, str2, LEN);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc);

--- a/unittests/test_wcsncpy_s.c
+++ b/unittests/test_wcsncpy_s.c
@@ -70,8 +70,8 @@
 #include "test_private.h"
 #include "safe_str_lib.h"
 
+#define LEN   128
 #define MAX   ( 128*4 )
-#define LEN   ( 128*4 )
 
 static wchar_t   str1[LEN];
 static wchar_t   str2[LEN];
@@ -118,7 +118,7 @@ printf("Test #%d:\n", ++testno);
 /* 3  Test for too large destination size              */
 	printf("Test #%d:\n", ++testno);
 
-	rc = wcsncpy_s(str1, (RSIZE_MAX_STR+1), str2, LEN);
+	rc = wcsncpy_s(str1, (RSIZE_MAX_STR/sizeof(wchar_t))+1, str2, LEN);
 	if (rc != ESLEMAX) {
 		printf("%s %u   Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc );
@@ -177,7 +177,7 @@ printf("Test #%d:\n", ++testno);
 /* 6  Test for too large source size              */
 	printf("Test #%d:\n", ++testno);
 
-	rc = wcsncpy_s(str1, LEN, str2, (RSIZE_MAX_STR+1));
+	rc = wcsncpy_s(str1, LEN, str2, (RSIZE_MAX_STR/sizeof(wchar_t))+1);
 	if (rc != ESLEMAX) {
 		printf("%s %u   Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc );

--- a/unittests/test_wcsncpy_s.c
+++ b/unittests/test_wcsncpy_s.c
@@ -200,7 +200,7 @@ printf("Test #%d:\n", ++testno);
 /* 7  Test for Src is same as dest, overlapping buffers not allowed */
     printf("Test #%d:\n", ++testno);
 
-    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
     rc = wcsncpy_s(str1, 5, str1, LEN);
     if (rc != ESOVRLP) {
@@ -225,7 +225,7 @@ printf("Test #%d:\n", ++testno);
 /* 8  Test overlapping buffers fails            */
     printf("Test #%d:\n", ++testno);
 
-    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
 	rc = wcsncpy_s(str1, LEN, &str1[5], 30);
     if (rc != ESOVRLP) {
@@ -329,7 +329,7 @@ printf("Test #%d:\n", ++testno);
 /* 12  Test overlapping buffers fails (dest > src )   */
 	printf("Test #%d:\n", ++testno);
 
-	wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+	wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
 	rc = wcsncpy_s(&str1[5], LEN, str1, 30);
 	if (rc != ESOVRLP) {

--- a/unittests/test_wcsncpy_s.c
+++ b/unittests/test_wcsncpy_s.c
@@ -265,7 +265,7 @@ printf("Test #%d:\n", ++testno);
 					 __FUNCTION__, __LINE__,  rc );
 	}
 
-    rc = memcmp_s(str1, LEN, str2, (10)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (10)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u   Error -%ls- <> -%ls-\n",
                      __FUNCTION__, __LINE__,  str1, str2);
@@ -291,7 +291,7 @@ printf("Test #%d:\n", ++testno);
 					 __FUNCTION__, __LINE__,  rc );
 	}
 
-	rc = memcmp_s(str1, LEN, str2, (sz+1)*sizeof(wchar_t), &ind );
+	rc = memcmp_s(str1, MAX, str2, (sz+1)*sizeof(wchar_t), &ind );
 	if (ind != 0) {
 		printf("%s %u   Error -%ls- <> -%ls-\n",
 					 __FUNCTION__, __LINE__,  str1, str2);
@@ -369,7 +369,7 @@ printf("Test #%d:\n", ++testno);
 					 __FUNCTION__, __LINE__,  rc );
 	}
 
-	rc = memcmp_s(str1, LEN, str2, (17)*sizeof(wchar_t), &ind );
+	rc = memcmp_s(str1, MAX, str2, (17)*sizeof(wchar_t), &ind );
 	if (ind != 0) {
 		printf("%s %u   Error -%ls- <> -%ls-\n",
 					 __FUNCTION__, __LINE__,  str1, str2);
@@ -395,7 +395,7 @@ printf("Test #%d:\n", ++testno);
 					 __FUNCTION__, __LINE__,  rc );
 	}
 
-	rc = memcmp_s(str2, LEN, str1, (sz+1)*sizeof(wchar_t), &ind );
+	rc = memcmp_s(str2, MAX, str1, (sz+1)*sizeof(wchar_t), &ind );
 	if (ind != 0) {
 		printf("%s %u   Error -%ls- <> -%ls-\n",
 					 __FUNCTION__, __LINE__,  str2, str1);
@@ -449,7 +449,7 @@ printf("Test #%d:\n", ++testno);
             printf("%s %u (sz=%lu <> 5) Error rc=%u \n",
                          __FUNCTION__, __LINE__,  sz, rc );
     }
-    rc = memcmp_s(str1, LEN, str2, (sz)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (sz)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls- <> -%ls-  (size=%lu) Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, str2, sz, rc );
@@ -471,7 +471,7 @@ printf("Test #%d:\n", ++testno);
                      __FUNCTION__, __LINE__,  rc );
     }
 
-    rc = memcmp_s(str1, LEN, str2, (3)*sizeof(wchar_t), &ind );
+    rc = memcmp_s(str1, MAX, str2, (3)*sizeof(wchar_t), &ind );
     if (ind != 0) {
         printf("%s %u -%ls-  Error rc=%u \n",
                      __FUNCTION__, __LINE__,  str1, rc );

--- a/unittests/test_wcsnlen_s.c
+++ b/unittests/test_wcsnlen_s.c
@@ -92,7 +92,7 @@ printf("Test #%d:\n", ++testno);
 /* 3  Test for length is equal to maximum */
     printf("Test #%d:\n", ++testno);
 
-    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+    wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
     rc = wcsnlen_s(str1, 41);
     if (rc != 40) {
@@ -104,7 +104,7 @@ printf("Test #%d:\n", ++testno);
 /* 4  Test for return length is equal to dmax */
 	printf("Test #%d:\n", ++testno);
 
-	wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 42);
+	wmemcpy_s(str1, LEN, L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 41);
 
 	rc = wcsnlen_s(str1, 20);
 	if (rc != 20) {

--- a/unittests/test_wcsnlen_s.c
+++ b/unittests/test_wcsnlen_s.c
@@ -53,8 +53,8 @@
 #include "test_private.h"
 #include "safe_str_lib.h"
 
+#define LEN   128
 #define MAX   ( 128*4 )
-#define LEN   ( 128*4 )
 
 static wchar_t   str1[LEN];
 

--- a/unittests/test_wmemcpy_s.c
+++ b/unittests/test_wmemcpy_s.c
@@ -59,7 +59,7 @@
 #include "test_private.h"
 #include "safe_mem_lib.h"
 
-#define LEN   ( 256*4 )
+#define LEN   256
 
 static wchar_t  mem1[LEN+2];
 static wchar_t  mem2[LEN+2];

--- a/unittests/test_wmemcpy_s.c
+++ b/unittests/test_wmemcpy_s.c
@@ -150,7 +150,7 @@ int test_wmemcpy_s (void)
 /* 8 Test for source overlaps into dest buffer */
 	printf("Test #%d:\n", ++testno);
 
-	rc = wmemcpy_s(&mem1[25], LEN, mem1, 26);
+	rc = wmemcpy_s(&mem1[25], LEN-25, mem1, 26);
 	if (rc != ESOVRLP) {
 		printf("%s %u   Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);

--- a/unittests/test_wmemmove_s.c
+++ b/unittests/test_wmemmove_s.c
@@ -67,7 +67,7 @@
 #include "test_private.h"
 #include "safe_mem_lib.h"
 
-#define LEN   ( 256*4 )
+#define LEN   256
 
 static wchar_t  mem1[LEN+2];
 static wchar_t  mem2[LEN+2];
@@ -109,7 +109,7 @@ int test_wmemmove_s (void)
 /* 3  Test for too large destination size              */
     printf("Test #%d:\n", ++testno);
 
-    rc = wmemmove_s(mem1, RSIZE_MAX_MEM+1, mem2, LEN);
+    rc = wmemmove_s(mem1, (RSIZE_MAX_MEM/sizeof(wchar_t))+1, mem2, LEN);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc);
@@ -404,7 +404,7 @@ int test_wmemmove_s (void)
 	for (i=0; i<LEN; i++) { mem1[i] = 35; }
 	for (i=0; i<LEN; i++) { mem2[i] = 55; }
 
-	rc = wmemmove_s((wchar_t)(((char *)mem1)+1), LEN, mem2, 10);
+	rc = wmemmove_s((wchar_t*)(((char *)mem1)+1), LEN, mem2, 10);
 	if (rc != EOK) {
 		printf("%s %u  Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);
@@ -430,7 +430,7 @@ int test_wmemmove_s (void)
 	for (i=0; i<LEN; i++) { mem1[i] = 35; }
 	for (i=0; i<LEN; i++) { mem2[i] = 55; }
 
-	rc = wmemmove_s((wchar_t)(((char *)mem1)+2), LEN, mem2, 10);
+	rc = wmemmove_s((wchar_t*)(((char *)mem1)+2), LEN, mem2, 10);
 	if (rc != EOK) {
 		printf("%s %u  Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);

--- a/unittests/test_wmemset_s.c
+++ b/unittests/test_wmemset_s.c
@@ -101,7 +101,7 @@ int test_wmemset_s (void)
 
     value = 34;
 
-    rc = wmemset_s(mem1, value, (RSIZE_MAX_MEM+1));
+    rc = wmemset_s(mem1, value, (RSIZE_MAX_MEM/sizeof(wchar_t))+1);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__, rc);


### PR DESCRIPTION
1) Fix unit tests to handle larger values of RSIZE_MAX up to ~((rsize_t)0b11111).
2) Fix ASAN errors in test_w* unit tests.
3) Distinguish between LEN and MAX values in test_w* unit tests. LEN is supposed to be used for wide-functions, while MAX is supposed to be used with non-wide functions.