### PR TITLE
safestringlib: drop -mmitigate-rop for gcc greater then 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,9 @@ target_compile_options(${PROJECT_NAME}_objlib
                        PRIVATE --param ssp-buffer-size=4 -ftrapv)
 target_compile_options(${PROJECT_NAME}_objlib PRIVATE -fPIE -fPIC)
 
-if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+if(CMAKE_COMPILER_IS_GNUCC AND
+   CMAKE_C_COMPILER_VERSION VERSION_GREATER 6 AND
+   CMAKE_C_COMPILER_VERSION VERSION_LESS 9)
     target_compile_options(${PROJECT_NAME}_objlib PRIVATE -mmitigate-rop)
 endif()
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z noexecstack -z relro -z now")


### PR DESCRIPTION
-mmitigate-rop was deprecated from the gcc v 9.1 and greater
"
This option is fairly ineffective, and in the light of CET, nobody
seems interested to improve it. Deprecate the option, so it won't lure
developers to the land of false security.
"

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>