### PR TITLE
safestringlib: unittests: strcasestr requires _GNU_SOURCE

### DIFF
--- a/unittests/test_strcasestr_s.c
+++ b/unittests/test_strcasestr_s.c
@@ -5,6 +5,7 @@
  *------------------------------------------------------------------
  */
 
+#define _GNU_SOURCE
 #include "test_private.h"
 #include "safe_str_lib.h"
 


### PR DESCRIPTION
strcasestr requires _GNU_SOURCE definition.

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>