### PR TITLE
safestringlib: unittests: use correct casting in wmemmove_s

### DIFF
--- a/unittests/test_strcasestr_s.c
+++ b/unittests/test_strcasestr_s.c
@@ -131,7 +131,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error strcasestr_s() does not have same return as strcasestr() when str1 & str2 are zero length strings. rc=%u \n",
                      __FUNCTION__, __LINE__, rc);
         printf("str1:[%s]\n", str1);
@@ -158,7 +158,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error strcasestr_s() does not have same return value as strcasestr() when str2 is zero length string. rc=%u \n",
                              __FUNCTION__, __LINE__, rc);
         printf("str1:[%s]\n", str1);
@@ -186,7 +186,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error strcasestr_s() does not have same return value as strcasestr() when str2 is zero length string. rc=%u \n",
                                      __FUNCTION__, __LINE__, rc);
         printf("str1:[%s]\n", str1);
@@ -268,7 +268,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error strcasestr_s() does not have same return value as strcasestr() when str2 is substring of the end of str1. rc=%u \n",
                                      __FUNCTION__, __LINE__, rc);
         printf("str1:[%s]\n", str1);
@@ -299,7 +299,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error strcasestr_s() does not have same return value as strcasestr() when str2 is substring of middle of str1. rc=%u \n",
                                      __FUNCTION__, __LINE__, rc);
         printf("str1:[%s]\n", str1);
@@ -424,7 +424,7 @@ int test_strcasestr_s()
 
     /* compare to legacy */
     std_sub = strcasestr(str1, str2);
-    if ((int)sub != (int)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
+    if ((intptr_t)sub != (intptr_t)std_sub) { // comparison to handle 32-bit library return and 64-bit library return
         printf("%s %u  Error rc=%u \n",
                      __FUNCTION__, __LINE__, rc);
     }

--- a/unittests/test_wmemmove_s.c
+++ b/unittests/test_wmemmove_s.c
@@ -404,7 +404,7 @@ int test_wmemmove_s (void)
 	for (i=0; i<LEN; i++) { mem1[i] = 35; }
 	for (i=0; i<LEN; i++) { mem2[i] = 55; }
 
-	rc = wmemmove_s((wchar_t)(((char *)mem1)+1), LEN, mem2, 10);
+	rc = wmemmove_s((wchar_t *)(((char *)mem1)+1), LEN, mem2, 10);
 	if (rc != EOK) {
 		printf("%s %u  Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);
@@ -430,7 +430,7 @@ int test_wmemmove_s (void)
 	for (i=0; i<LEN; i++) { mem1[i] = 35; }
 	for (i=0; i<LEN; i++) { mem2[i] = 55; }
 
-	rc = wmemmove_s((wchar_t)(((char *)mem1)+2), LEN, mem2, 10);
+	rc = wmemmove_s((wchar_t *)(((char *)mem1)+2), LEN, mem2, 10);
 	if (rc != EOK) {
 		printf("%s %u  Error rc=%u \n",
 					 __FUNCTION__, __LINE__,  rc);


### PR DESCRIPTION
Cast pointer to wchar_t and not to the scalar.

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>