### PR TITLE
safestringlib: safec:  fix heap-buffer-overflow

### DIFF
--- a/safeclib/strcasestr_s.c
+++ b/safeclib/strcasestr_s.c
@@ -121,7 +121,7 @@ strcasestr_s (char *dest, rsize_t dmax,
         return (EOK);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
         i = 0;
         len = slen;
         dlen = dmax;

--- a/safeclib/strcspn_s.c
+++ b/safeclib/strcspn_s.c
@@ -113,7 +113,7 @@ strcspn_s (const char *dest, rsize_t dmax,
         return RCNEGATE(ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         /*
          * Scanning for exclusions, so if there is a match,

--- a/safeclib/strfirstchar_s.c
+++ b/safeclib/strfirstchar_s.c
@@ -88,7 +88,7 @@ strfirstchar_s (char *dest, rsize_t dmax, char c, char **first)
         return (ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if (*dest == c) {
             *first = dest;

--- a/safeclib/strisalphanumeric_s.c
+++ b/safeclib/strisalphanumeric_s.c
@@ -78,7 +78,7 @@ strisalphanumeric_s (const char *dest, rsize_t dmax)
         return (false);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if (( (*dest >= '0') && (*dest <= '9') )  ||
             ( (*dest >= 'a') && (*dest <= 'z') )  ||

--- a/safeclib/strisascii_s.c
+++ b/safeclib/strisascii_s.c
@@ -73,7 +73,7 @@ strisascii_s (const char *dest, rsize_t dmax)
         return (false);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
         if ((unsigned char)*dest > 127) {
             return (false);
         }

--- a/safeclib/strishex_s.c
+++ b/safeclib/strishex_s.c
@@ -76,7 +76,7 @@ strishex_s (const char *dest, rsize_t dmax)
         return (false);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if (((*dest >= '0') && (*dest <= '9')) ||
             ((*dest >= 'a') && (*dest <= 'f')) ||

--- a/safeclib/strislowercase_s.c
+++ b/safeclib/strislowercase_s.c
@@ -80,7 +80,7 @@ strislowercase_s (const char *dest, rsize_t dmax)
         return (false);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if ((*dest < 'a') || (*dest > 'z')) {
             return (false);

--- a/safeclib/strlastchar_s.c
+++ b/safeclib/strlastchar_s.c
@@ -88,7 +88,7 @@ strlastchar_s(char *dest, rsize_t dmax, char c, char **last)
         return (ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if (*dest == c) {
             *last = dest;

--- a/safeclib/strnlen_s.c
+++ b/safeclib/strnlen_s.c
@@ -76,7 +76,7 @@ strnlen_s (const char *dest, rsize_t dmax)
     }
 
     count = 0;
-    while (*dest && dmax) {
+    while (dmax && *dest) {
         count++;
         dmax--;
         dest++;

--- a/safeclib/strpbrk_s.c
+++ b/safeclib/strpbrk_s.c
@@ -115,7 +115,7 @@ strpbrk_s (char *dest, rsize_t dmax,
     /*
      * look for a matching char in the substring src
      */
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         ps = src;
         len = slen;

--- a/safeclib/strspn_s.c
+++ b/safeclib/strspn_s.c
@@ -111,7 +111,7 @@ strspn_s (const char *dest, rsize_t dmax,
         return RCNEGATE(ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         /*
          * Scan the entire src string for each dest character, counting

--- a/safeclib/strstr_s.c
+++ b/safeclib/strstr_s.c
@@ -119,7 +119,7 @@ strstr_s (char *dest, rsize_t dmax,
         return RCNEGATE(EOK);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
         i = 0;
         len = slen;
         dlen = dmax;

--- a/safeclib/strtolowercase_s.c
+++ b/safeclib/strtolowercase_s.c
@@ -76,7 +76,7 @@ strtolowercase_s (char *dest, rsize_t dmax)
         return (ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if ( (*dest >= 'A') && (*dest <= 'Z')) {
               *dest = (char)(*dest + (char)32);

--- a/safeclib/strtouppercase_s.c
+++ b/safeclib/strtouppercase_s.c
@@ -76,7 +76,7 @@ strtouppercase_s (char *dest, rsize_t dmax)
         return (ESLEMAX);
     }
 
-    while (*dest && dmax) {
+    while (dmax && *dest) {
 
         if ((*dest >= 'a') && (*dest <= 'z')) {
              *dest = (char)(*dest - 32);

--- a/safeclib/wcsnlen_s.c
+++ b/safeclib/wcsnlen_s.c
@@ -76,7 +76,7 @@ wcsnlen_s (const wchar_t *dest, rsize_t dmax)
     }
 
     count = 0;
-    while (*dest && dmax) {
+    while (dmax && *dest) {
         count++;
         dmax--;
         dest++;


### PR DESCRIPTION
When the pointer to dest is moved past the end of the array it is de-referenced in while loop condition before the control check of dmax.

Check for dmax before dereferencing dest

Reported-by: https://github.com/applesauce49
Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>

closes #29 