### PR TITLE
safestringlib: silence unused parameters warning in error handlers

### DIFF
--- a/safeclib/abort_handler_s.c
+++ b/safeclib/abort_handler_s.c
@@ -44,6 +44,8 @@
 
 void abort_handler_s(const char *msg, void *ptr, errno_t error)
 {
+    UNUSED(ptr);
+
     slprintf("ABORT CONSTRAINT HANDLER: (%u) %s\n", error,
          (msg) ? msg : "Null message");
     slabort();

--- a/safeclib/ignore_handler_s.c
+++ b/safeclib/ignore_handler_s.c
@@ -40,9 +40,11 @@
 
 void ignore_handler_s(const char *msg, void *ptr, errno_t error)
 {
+    UNUSED(ptr);
+    UNUSED(msg);
+    UNUSED(error);
 
     sldebug_printf("IGNORE CONSTRAINT HANDLER: (%u) %s\n", error,
                (msg) ? msg : "Null message");
-    return;
 }
 EXPORT_SYMBOL(ignore_handler_s)

--- a/safeclib/safeclib_private.h
+++ b/safeclib/safeclib_private.h
@@ -60,6 +60,8 @@
 
 #endif /* __KERNEL__ */
 
+#define UNUSED(x) (void)(x)
+
 #ifndef sldebug_printf
 #define sldebug_printf(...)
 #endif


### PR DESCRIPTION
The default ignore and abort handlers take ptr parameter which is unused, in addition in the  ignore_handler we use debug print macro which might be undefined and render also rest of the parameters unused.

Introduce UNUSED() macro that silence the warning.