### PR TITLE
safestring: align str rsize with the mem rsize

### DIFF
--- a/include/safe_lib.h
+++ b/include/safe_lib.h
@@ -32,11 +32,15 @@ extern "C" {
 typedef size_t  rsize_t;
 
 /*
+ * This is the original library decision:
  * We depart from the standard and allow memory and string operations to
  * have different max sizes. See the respective safe_mem_lib.h or
  * safe_str_lib.h files.
  */
 /* #define RSIZE_MAX (~(rsize_t)0)  - leave here for completeness */
+
+/* Bring back the standard */
+#define RSIZE_MAX        ( 256UL << 20 )     /* 256MB */
 
 typedef void (*constraint_handler_t) (const char * /* msg */,
                                       void *       /* ptr */,

--- a/include/safe_mem_lib.h
+++ b/include/safe_mem_lib.h
@@ -11,7 +11,7 @@
 #include "safe_lib.h"
 #include <wchar.h>
 
-#define RSIZE_MAX_MEM      ( 256UL << 20 )     /* 256MB */
+#define RSIZE_MAX_MEM      ( RSIZE_MAX )
 #define RSIZE_MAX_MEM16    ( RSIZE_MAX_MEM/2 )
 #define RSIZE_MAX_MEM32    ( RSIZE_MAX_MEM/4 )
 

--- a/include/safe_str_lib.h
+++ b/include/safe_str_lib.h
@@ -16,7 +16,7 @@
 #define RSIZE_MIN_STR      ( 1 )
 
 /* maximum sring length */
-#define RSIZE_MAX_STR      ( 4UL << 10 )      /* 4KB */
+#define RSIZE_MAX_STR      ( RSIZE_MAX )
 
 
 /* The makeup of a password */

--- a/unittests/test_strtolowercase_s.c
+++ b/unittests/test_strtolowercase_s.c
@@ -40,8 +40,10 @@ int test_strtolowercase_s()
 
 /*--------------------------------------------------*/
 
-    len = 99999;
-    rc = strtolowercase_s("test", len);
+    len = RSIZE_MAX_STR + 1;
+    strcpy(str, "TEST");
+
+    rc = strtolowercase_s(str, len);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc );

--- a/unittests/test_strtouppercase_s.c
+++ b/unittests/test_strtouppercase_s.c
@@ -53,11 +53,11 @@ int test_strtouppercase_s()
 
 /*--------------------------------------------------*/
 
-/* FIXME: known bug: this test causes a bus error if the string max size is
-   not restricted via RSIZE_MAX_STR */
-    len = 99999;
+    len = RSIZE_MAX_STR + 1;
+    strcpy (str, "test");
+
     //printf("debug - 04\n");
-    rc = strtouppercase_s("test", len);
+    rc = strtouppercase_s(str, len);
     if (rc != ESLEMAX) {
         printf("%s %u   Error rc=%u \n",
                      __FUNCTION__, __LINE__,  rc );


### PR DESCRIPTION
The original library departed from standard and set different RSIZE_STR_MAX to 4K and RSIZE_MEM_MAX to 256M

The original comment doesn't explain why this decision was done.

/*
 * We depart from the standard and allow memory and string operations to
 * have different max sizes. See the respective safe_mem_lib.h or
 * safe_str_lib.h files. */

In this change we allign both RSIZE_STR_MAX and RSIZE_MEM_MAX to same 256M size via standard RSIZE_MAX