### PR TITLE
safestringlib: avoid redefining RSIZE_MAX

### DIFF
--- a/include/safe_lib.h
+++ b/include/safe_lib.h
@@ -39,8 +39,10 @@ typedef size_t  rsize_t;
  */
 /* #define RSIZE_MAX (~(rsize_t)0)  - leave here for completeness */
 
+#ifndef RSIZE_MAX
 /* Bring back the standard */
 #define RSIZE_MAX        ( 256UL << 20 )     /* 256MB */
+#endif /* RSIZE_MAX */
 
 typedef void (*constraint_handler_t) (const char * /* msg */,
                                       void *       /* ptr */,


### PR DESCRIPTION
Do not redefine RSIZE_MAX when it is defined in system includes.

Fixes: https://github.com/intel/safestringlib/issues/78